### PR TITLE
Add a script that verifies article code and output

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,14 @@ updates:
       # Prettier / husky / lint-staged は記事の内容に影響しないため1つの PR にまとめる
       dev-dependencies:
         dependency-type: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,22 @@
+name: check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Check article code and output
+        run: npm run check:articles

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 CLAUDE.md
 .claude/
+.article-check/

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,0 +1,6 @@
+export default {
+  "*.{md,json,yml,yaml}": "prettier --write",
+  // 記事を触ったときだけ検証する。ファイル名を渡さないよう関数で書いている
+  // (このスクリプトは articles/ 全体を走査するため)
+  "articles/*.md": () => "npm run check:articles",
+};

--- a/articles/category-theory-practice-applicative.md
+++ b/articles/category-theory-practice-applicative.md
@@ -47,6 +47,8 @@ function apOptional<A, B>(fab: Optional<(a: A) => B>, fa: Optional<A>): Optional
 
 引数の並びは `fmapOptional` と揃えてあります。どちらも関数が先、箱が後です。違いは第1引数だけで、`fmapOptional` は素の関数を取るのに対し、`apOptional` はそれが箱に入っています。
 
+<!-- check:skip -->
+
 ```typescript
 fmapOptional: (f: (a: A) => B, fa: Optional<A>) => Optional<B>;
 apOptional: (fab: Optional<(a: A) => B>, fa: Optional<A>) => Optional<B>;
@@ -66,7 +68,11 @@ const attendance: Optional<number> = { hasValue: true, value: 24 }; // 出席日
 判定に使いたいのは「点数が60点以上、かつ出席日数が20日以上」という**2引数**の条件です。これをカリー化して `fmapOptional` に渡すと、こうなります。
 
 ```typescript
-const canAdvance = (s: number) => (a: number) => s >= 60 && a >= 20;
+const PASS_MARK = 60;
+const MIN_ATTENDANCE = 20;
+
+const canAdvance = (s: number) => (a: number) =>
+  s >= PASS_MARK && a >= MIN_ATTENDANCE;
 
 const boxedFn = fmapOptional(canAdvance, score);
 // boxedFn の型: Optional<(a: number) => boolean>
@@ -75,6 +81,8 @@ const boxedFn = fmapOptional(canAdvance, score);
 **関数が箱に入った状態**になりました。あとは出席日数を食わせるだけなのですが、`fmapOptional` にはもう渡せません。第1引数は**素の関数**でなければならないのに、こちらが持っているのは**箱に入った関数**だからです。
 
 つまり `fmap` は「箱の外にある関数」を「箱の中の値」に適用する道具なので、関数自体が箱に入った瞬間に手が届かなくなります。ここを埋めるのが `ap` です。
+
+<!-- check:skip -->
 
 ```typescript
 fmapOptional(boxedFn, attendance); // 型が合わない
@@ -89,10 +97,9 @@ apOptional(boxedFn, attendance); // 通る
 
 **制約: 中身を `if` で直接分解しないこと。** `pureOptional` と `apOptional` だけを使います。
 
-```typescript
-const PASS_MARK = 60;
-const MIN_ATTENDANCE = 20;
+<!-- check:skip -->
 
+```typescript
 // TODO: pureOptional と apOptional だけを使って書く
 function judge(
   score: Optional<number>,
@@ -107,9 +114,6 @@ function judge(
 ## 解答
 
 ```typescript
-const canAdvance = (s: number) => (a: number) =>
-  s >= PASS_MARK && a >= MIN_ATTENDANCE;
-
 function judge(
   score: Optional<number>,
   attendance: Optional<number>,
@@ -276,6 +280,8 @@ apOptional(pureOptional(half), x); // { hasValue: true, value: 41 }
 今回うまくいったのは、**点数と出席日数が互いに独立している**からです。出席日数を取ってくるのに点数の値は要りませんし、逆も同じです。だから「両方を箱から出して関数に渡す」という形に収まりました。
 
 これが崩れるのは、後の値が前の値に依存する場合です。例えば「本試験が不合格だった生徒にだけ追試の点数がある」という状況を考えると、追試の点数を取りに行くかどうかが本試験の**値**によって決まります。
+
+<!-- check:skip -->
 
 ```typescript
 // 本試験の点数によって、次に何を取りに行くかが変わる

--- a/articles/category-theory-practice-functor-category.md
+++ b/articles/category-theory-practice-functor-category.md
@@ -67,6 +67,8 @@ const f = (point: number) => point >= PASS_MARK;
 
 一覧表示のために、`ApiResult<A>` を配列 `A[]` に変換する $\sigma$ を書きます。値があれば要素1つの配列、なければ空配列とします。
 
+<!-- check:skip -->
+
 ```typescript
 // TODO: A について何も知らないまま書く
 function toArray<A>(fa: ApiResult<A>): A[] {
@@ -104,6 +106,8 @@ $$
 # 練習2: 自然変換をつなぐ
 
 $\tau : \mathrm{Optional} \Rightarrow \mathrm{ApiResult}$ と $\sigma : \mathrm{ApiResult} \Rightarrow \mathrm{Array}$ が揃ったので、つないで $\mathrm{Optional} \Rightarrow \mathrm{Array}$ を作ります。これが自然変換になっているかを確かめます。
+
+<!-- check:skip -->
 
 ```typescript
 // TODO: toApiResult と toArray をつなぐ
@@ -187,6 +191,14 @@ function idOptional<A>(fa: Optional<A>): Optional<A> {
 ```
 
 自然性は $\mathrm{id}_{F} \circ F(f) = F(f) \circ \mathrm{id}_{F}$ で、どちらも $F(f)$ そのものなので成り立ちます。
+
+```typescript
+for (const score of scores) {
+  const lhs = idOptional(fmapOptional(f)(score));
+  const rhs = fmapOptional(f)(idOptional(score));
+  console.log(JSON.stringify(score).padEnd(28), same(lhs, rhs));
+}
+```
 
 ```
 {"hasValue":true,"value":82} true

--- a/articles/category-theory-practice-functor.md
+++ b/articles/category-theory-practice-functor.md
@@ -37,7 +37,8 @@ function fmapOptional<A, B>(f: (a: A) => B): (fa: Optional<A>) => Optional<B> {
 `fmapOptional` は関数を受け取って関数を返します。箱は引数に取りません。
 
 ```typescript
-const f = (point: number) => point >= 60; // number -> boolean
+const PASS_MARK = 60;
+const f = (point: number) => point >= PASS_MARK; // number -> boolean
 const lifted = fmapOptional(f); // Optional<number> -> Optional<boolean>
 ```
 
@@ -51,9 +52,9 @@ const lifted = fmapOptional(f); // Optional<number> -> Optional<boolean>
 
 **制約: 中身の `Optional` を自分で分解しないこと。** つまり `if (score.hasValue)` を書かず、`fmapOptional` だけで書きます。
 
-```typescript
-const PASS_MARK = 60;
+<!-- check:skip -->
 
+```typescript
 // TODO: fmapOptional だけを使って書く
 const isPassing: (score: Optional<number>) => Optional<boolean> = /* ここを実装 */;
 ```

--- a/articles/category-theory-practice-natural-transformation.md
+++ b/articles/category-theory-practice-natural-transformation.md
@@ -36,6 +36,8 @@ function fmapOptional<A, B>(f: (a: A) => B): (fa: Optional<A>) => Optional<B> {
 ```typescript
 const PASS_MARK = 60;
 const f = (point: number) => point >= PASS_MARK;
+
+const score: Optional<number> = { hasValue: true, value: 82 };
 ```
 
 # 練習問題
@@ -46,7 +48,11 @@ const f = (point: number) => point >= PASS_MARK;
 type ApiResult<A> =
   | { status: "ok"; data: A }
   | { status: "empty" };
+```
 
+<!-- check:skip -->
+
+```typescript
 function toApiResult<A>(fa: Optional<A>): ApiResult<A> {
   // ここを実装
 }
@@ -73,6 +79,8 @@ function toApiResult<A>(fa: Optional<A>): ApiResult<A> {
 「`fmap` を先にやるか、変換を先にやるかで結果が変わらない」を確かめます。
 
 素朴に書くと次の2つを比べたくなりますが、
+
+<!-- check:skip -->
 
 ```typescript
 toApiResult(fmapOptional(f)(score));

--- a/articles/codebuild-ecr-push-error.md
+++ b/articles/codebuild-ecr-push-error.md
@@ -32,6 +32,8 @@ EOF
 CodeBuild から ECR にイメージを PUSH するときには、ECR への PUSH 権限を付与する必要があったのですが、その権限を付与していませんでした。
 今回は CDK を使っていたので、以下のように権限を付与するコードを追加する必要がありました。
 
+<!-- check:skip -->
+
 ```typescript
 const ecrRepo = ecr.Repository.fromRepositoryName(/* ECRの情報 */);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,348 @@
       "devDependencies": {
         "husky": "^9.1.7",
         "lint-staged": "^17.2.0",
-        "prettier": "^3.9.6"
+        "prettier": "^3.9.6",
+        "typescript": "^7.0.2"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/bundle-name": {
@@ -234,6 +575,41 @@
         "node": ">=18"
       }
     },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
     "node_modules/wsl-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
@@ -282,6 +658,146 @@
     }
   },
   "dependencies": {
+    "@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "dev": true,
+      "optional": true
+    },
     "bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -392,6 +908,34 @@
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
       "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true
+    },
+    "typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "requires": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
     },
     "wsl-utils": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
     "check:articles": "node scripts/check-articles.mjs",
     "prepare": "husky"
   },
-  "lint-staged": {
-    "*.{md,json,yml,yaml}": "prettier --write"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nomi3/zenn.git"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "preview": "zenn preview --port 8000",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "check:articles": "node scripts/check-articles.mjs",
     "prepare": "husky"
   },
   "lint-staged": {
@@ -30,6 +31,7 @@
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^17.2.0",
-    "prettier": "^3.9.6"
+    "prettier": "^3.9.6",
+    "typescript": "^7.0.2"
   }
 }

--- a/scripts/check-articles.mjs
+++ b/scripts/check-articles.mjs
@@ -1,0 +1,179 @@
+// 記事に載せた TypeScript を、記事のテキストそのものから検証する。
+//
+//   1. ```typescript ブロックを上から順に連結して1ファイルにし、型チェックする
+//   2. それを実行し、標準出力を記事中の出力ブロック(言語指定なしの ```)と突き合わせる
+//
+// 1記事ぶんを連結するので、前の節で定義した型や関数を後の節で使う書き方が
+// そのまま検証できる。出力例を手で書き写す事故も 2 で防げる。
+//
+// 意図的に検証できないブロック(TODO のスタブ、「型が合わない」例、
+// 外部パッケージに依存するコード、コードを載せていない出力例など)は、
+// 直前に次の行を置くと除外される。HTML コメントなので記事の表示には出ない。
+//
+//   <!-- check:skip -->
+//
+// 使い方: npm run check:articles
+
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+const ARTICLES_DIR = "articles";
+const WORK_DIR = ".article-check";
+const SKIP_MARKER = "<!-- check:skip -->";
+
+/**
+ * 記事を走査して、除外指定されていないコードブロックと出力ブロックを集める。
+ * 言語指定が typescript のものをコード、指定なしのものを期待する出力とみなす。
+ */
+function extractBlocks(markdown) {
+  const lines = markdown.split("\n");
+  const code = [];
+  const output = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const fence = /^```(\w*)\s*$/.exec(lines[i]);
+    if (!fence) continue;
+
+    const lang = fence[1];
+    const start = i + 1;
+    let end = start;
+    while (end < lines.length && !/^```\s*$/.test(lines[end])) end++;
+
+    if (lang === "typescript" || lang === "") {
+      // 直前の非空行が除外マーカーかどうか
+      let prev = i - 1;
+      while (prev >= 0 && lines[prev].trim() === "") prev--;
+      const skipped = prev >= 0 && lines[prev].trim() === SKIP_MARKER;
+
+      if (!skipped) {
+        const body = lines.slice(start, end).join("\n");
+        (lang === "typescript" ? code : output).push({ line: start + 1, body });
+      }
+    }
+
+    i = end;
+  }
+
+  return { code, output };
+}
+
+/** 末尾の空白と空行を落として比較しやすくする */
+function normalize(text) {
+  return text
+    .split("\n")
+    .map((l) => l.replace(/\s+$/, ""))
+    .join("\n")
+    .replace(/\n+$/, "");
+}
+
+rmSync(WORK_DIR, { recursive: true, force: true });
+mkdirSync(WORK_DIR, { recursive: true });
+
+const targets = [];
+for (const file of readdirSync(ARTICLES_DIR).sort()) {
+  if (!file.endsWith(".md")) continue;
+
+  const markdown = readFileSync(path.join(ARTICLES_DIR, file), "utf8");
+  const { code, output } = extractBlocks(markdown);
+  if (code.length === 0) continue;
+
+  // どの行から来たブロックかを追えるように印を付けておく。
+  // 末尾の export {} は、記事どうしで同名の型や関数がぶつからないよう
+  // 生成ファイルをモジュール扱いにするためのもの。
+  const source =
+    code
+      .map((b) => `// ${ARTICLES_DIR}/${file}:${b.line}\n${b.body}`)
+      .join("\n\n") + "\n\nexport {};\n";
+
+  const stem = file.replace(/\.md$/, "");
+  const generated = path.join(WORK_DIR, `${stem}.ts`);
+  writeFileSync(generated, source);
+
+  targets.push({
+    article: file,
+    generated,
+    compiled: path.join(WORK_DIR, "js", `${stem}.js`),
+    codeBlocks: code.length,
+    expected: output.map((b) => b.body),
+  });
+}
+
+if (targets.length === 0) {
+  console.log("検証対象の TypeScript ブロックはありませんでした。");
+  process.exit(0);
+}
+
+for (const t of targets) {
+  const n = t.expected.length;
+  console.log(
+    `${t.article} (コード ${t.codeBlocks} ブロック / 出力 ${n} ブロック)`,
+  );
+}
+console.log("");
+
+function fail(message) {
+  console.error("");
+  console.error(message);
+  console.error(`生成物は ${WORK_DIR}/ に残してあります。`);
+  console.error(
+    `各ブロックの先頭にある // articles/xxx.md:N が、元の記事の行番号です。`,
+  );
+  console.error(
+    `意図的に検証できないブロックなら、記事側で直前に ${SKIP_MARKER} を置いてください。`,
+  );
+  process.exit(1);
+}
+
+// 1. 型チェック
+try {
+  execFileSync(
+    "npx",
+    [
+      "tsc",
+      "--strict",
+      "--skipLibCheck",
+      "--target",
+      "es2020",
+      "--module",
+      "commonjs",
+      "--outDir",
+      path.join(WORK_DIR, "js"),
+      ...targets.map((t) => t.generated),
+    ],
+    { stdio: "inherit" },
+  );
+} catch {
+  fail("型チェックに失敗しました。");
+}
+
+// 2. 実行して出力を突き合わせ
+let mismatched = false;
+for (const t of targets) {
+  if (t.expected.length === 0) continue;
+
+  const actual = normalize(
+    execFileSync("node", [t.compiled], { encoding: "utf8" }),
+  );
+  const expected = normalize(t.expected.join("\n"));
+
+  if (actual !== expected) {
+    mismatched = true;
+    console.error(`出力が記事と一致しません: ${t.article}`);
+    console.error("--- 記事に書かれている内容 ---");
+    console.error(expected);
+    console.error("--- 実際の出力 ---");
+    console.error(actual);
+    console.error("");
+  }
+}
+if (mismatched) fail("出力の突き合わせに失敗しました。");
+
+rmSync(WORK_DIR, { recursive: true, force: true });
+console.log("型チェックと出力の突き合わせが通りました。");


### PR DESCRIPTION
記事に載せた TypeScript を、記事のテキストそのものから検証するスクリプトを追加し、pre-commit と CI に組み込みます。

## きっかけ

これまでの検証は、記事とは別に書いたスクラッチファイルで行っていました。記事とスクラッチの間は手で書き写しているため、**ズレても検出できない**状態でした。

実際にバグが1件出ています。自然変換の記事で `score` がどこにも宣言されていませんでした。記事分割のときに `const score` が関手の記事側へ移ってしまい、そのまま公開されていました。

## やること

```bash
npm run check:articles
```

1. 記事中の ` ```typescript ` ブロックを上から順に連結して1ファイルにし、型チェックする
2. それを実行し、標準出力を記事中の出力ブロック(言語指定なしの ` ``` `)と突き合わせる

1記事ぶんを連結するので、前の節で定義した型や関数を後の節で使う書き方がそのまま検証できます。2 によって、出力例の写し間違いも検出されます。

意図的に検証できないブロックは直前に `<!-- check:skip -->` を置くと除外されます。HTML コメントなのでレンダリング結果には出ません(プレビューで確認済み)。

## 実行するタイミング

| | 内容 |
| --- | --- |
| pre-commit | `articles/*.md` がステージされたときだけ実行。lint-staged の関数記法でファイル名を渡さないようにしている |
| CI | push(main) と PR で実行。`--no-verify` で回避されても止まる |

CI には `format:check` を入れていません。既存記事31本が未整形で落ちるためです。一括整形するなら別 PR で。

## このスクリプトが見つけた記事の不備

| 記事 | 内容 |
| --- | --- |
| 自然変換 | `score` が未宣言(分割時の取りこぼし) |
| アプリカティブ関手 | `canAdvance` が二重定義。マジックナンバー版と定数版が混在していた |
| 関手圏 | 恒等自然変換の出力例に対応するコードが記事に無かった |

いずれも修正済みです。

## 動作確認

- 全記事グリーン
- 出力を1文字書き換えると差分を表示して失敗することを確認
- 型を壊すと `error TS2365` で失敗することを確認
- 壊れた記事をステージしてコミットすると、pre-commit が止めることを確認
- 記事以外だけのコミットでは記事チェックが走らないことを確認

## ついでに

`.github/workflows` を追加したので、Dependabot に `github-actions` の項目も足しています。